### PR TITLE
fix build backend for CI compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = ["setuptools>=64", "wheel"]
-build-backend = "setuptools.backends._legacy:_Backend"
+build-backend = "setuptools.build_meta"
 
 [project]
 name = "gw_remnant"


### PR DESCRIPTION
Replace setuptools.backends._legacy:_Backend with the standard setuptools.build_meta backend, which is supported across all setuptools versions.